### PR TITLE
feat #3: buf breaking output parser

### DIFF
--- a/internal/buf/parser.go
+++ b/internal/buf/parser.go
@@ -2,60 +2,227 @@
 // categorized breaking changes for downstream analysis and reporting.
 package buf
 
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // ChangeCategory classifies the type of breaking change.
 type ChangeCategory string
 
 const (
-	// CategoryFieldRemoved indicates a field was removed from a message.
-	CategoryFieldRemoved ChangeCategory = "FIELD_REMOVED"
-	// CategoryFieldTypeChanged indicates a field's type was changed.
-	CategoryFieldTypeChanged ChangeCategory = "FIELD_TYPE_CHANGED"
-	// CategoryFieldReserved indicates a field number conflict with reserved range.
-	CategoryFieldReserved ChangeCategory = "FIELD_RESERVED"
-	// CategoryServiceRemoved indicates a service was removed.
-	CategoryServiceRemoved ChangeCategory = "SERVICE_REMOVED"
-	// CategoryMethodRemoved indicates an RPC method was removed.
-	CategoryMethodRemoved ChangeCategory = "METHOD_REMOVED"
-	// CategoryMethodSignatureChanged indicates a method's input/output type changed.
+	CategoryFieldRemoved          ChangeCategory = "FIELD_REMOVED"
+	CategoryFieldTypeChanged      ChangeCategory = "FIELD_TYPE_CHANGED"
+	CategoryFieldReserved         ChangeCategory = "FIELD_RESERVED"
+	CategoryServiceRemoved        ChangeCategory = "SERVICE_REMOVED"
+	CategoryMethodRemoved         ChangeCategory = "METHOD_REMOVED"
 	CategoryMethodSignatureChanged ChangeCategory = "METHOD_SIGNATURE_CHANGED"
-	// CategoryMessageRemoved indicates a message was removed.
-	CategoryMessageRemoved ChangeCategory = "MESSAGE_REMOVED"
-	// CategoryEnumRemoved indicates an enum was removed.
-	CategoryEnumRemoved ChangeCategory = "ENUM_REMOVED"
-	// CategoryEnumValueRemoved indicates an enum value was removed.
-	CategoryEnumValueRemoved ChangeCategory = "ENUM_VALUE_REMOVED"
-	// CategoryUnknown indicates an unrecognized change type.
-	CategoryUnknown ChangeCategory = "UNKNOWN"
+	CategoryMessageRemoved        ChangeCategory = "MESSAGE_REMOVED"
+	CategoryEnumRemoved           ChangeCategory = "ENUM_REMOVED"
+	CategoryEnumValueRemoved      ChangeCategory = "ENUM_VALUE_REMOVED"
+	CategoryUnknown               ChangeCategory = "UNKNOWN"
+)
+
+// Severity indicates the impact level of a breaking change.
+type Severity string
+
+const (
+	SeverityHigh   Severity = "high"
+	SeverityMedium Severity = "medium"
+	SeverityLow    Severity = "low"
 )
 
 // BreakingChange represents a single breaking change detected by buf.
 type BreakingChange struct {
-	// File is the proto file where the change was detected.
-	File string
-	// Line is the line number in the proto file (0 if unknown).
-	Line int
-	// Category classifies the type of breaking change.
-	Category ChangeCategory
-	// Description is the human-readable description from buf.
-	Description string
-	// AffectedEntity is the fully qualified name of the affected proto entity.
+	File           string
+	Line           int
+	Column         int
+	Category       ChangeCategory
+	Severity       Severity
+	Description    string
 	AffectedEntity string
 }
 
 // BreakingReport is the structured result of parsing buf breaking output.
 type BreakingReport struct {
-	// Changes is the list of all detected breaking changes.
-	Changes []BreakingChange
-	// TotalCount is the total number of breaking changes.
+	Changes    []BreakingChange
 	TotalCount int
 }
 
+// categorySeverity maps categories to their default severity.
+var categorySeverity = map[ChangeCategory]Severity{
+	CategoryFieldRemoved:           SeverityHigh,
+	CategoryFieldTypeChanged:       SeverityHigh,
+	CategoryServiceRemoved:         SeverityHigh,
+	CategoryMethodRemoved:          SeverityHigh,
+	CategoryMethodSignatureChanged: SeverityHigh,
+	CategoryMessageRemoved:         SeverityHigh,
+	CategoryEnumRemoved:            SeverityMedium,
+	CategoryEnumValueRemoved:       SeverityMedium,
+	CategoryFieldReserved:          SeverityLow,
+	CategoryUnknown:                SeverityMedium,
+}
+
+// categoryPatterns maps substrings in buf output to categories.
+var categoryPatterns = []struct {
+	pattern  string
+	category ChangeCategory
+}{
+	// Signature changes must match before service/method removal (more specific first)
+	{"changed request type", CategoryMethodSignatureChanged},
+	{"changed response type", CategoryMethodSignatureChanged},
+	{"input type changed", CategoryMethodSignatureChanged},
+	{"output type changed", CategoryMethodSignatureChanged},
+	{"request type changed", CategoryMethodSignatureChanged},
+	{"response type changed", CategoryMethodSignatureChanged},
+	// Field changes
+	{"field type changed", CategoryFieldTypeChanged},
+	{"changed type", CategoryFieldTypeChanged},
+	{"Previously present field", CategoryFieldRemoved},
+	// Service/method removal (after signature changes)
+	{"Previously present service", CategoryServiceRemoved},
+	{"Previously present method", CategoryMethodRemoved},
+	// Message removal
+	{"Previously present message", CategoryMessageRemoved},
+	// Enum changes (enum value before enum)
+	{"Previously present enum value", CategoryEnumValueRemoved},
+	{"Previously present enum", CategoryEnumRemoved},
+	// Reserved
+	{"reserved", CategoryFieldReserved},
+}
+
 // ParseOutput parses the raw text output of `buf breaking` into a structured report.
-// Returns an error if the output cannot be parsed.
+// buf breaking output format: file:line:column:message
+// Empty input returns a report with zero changes (no breaking changes detected).
 func ParseOutput(rawOutput string) (*BreakingReport, error) {
-	// Placeholder: will be implemented in Issue #3
+	rawOutput = strings.TrimSpace(rawOutput)
+	if rawOutput == "" {
+		return &BreakingReport{Changes: nil, TotalCount: 0}, nil
+	}
+
+	var changes []BreakingChange
+	scanner := bufio.NewScanner(strings.NewReader(rawOutput))
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		change, err := parseLine(line)
+		if err != nil {
+			continue
+		}
+
+		changes = append(changes, change)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning buf output: %w", err)
+	}
+
 	return &BreakingReport{
-		Changes:    nil,
-		TotalCount: 0,
+		Changes:    changes,
+		TotalCount: len(changes),
 	}, nil
+}
+
+// parseLine parses a single line of buf breaking output.
+// Expected format: "file:line:column:message" or "file:line:message"
+func parseLine(line string) (BreakingChange, error) {
+	parts := strings.SplitN(line, ":", 4)
+	if len(parts) < 3 {
+		return BreakingChange{}, fmt.Errorf("unexpected format: %s", line)
+	}
+
+	file := parts[0]
+	lineNum, err := strconv.Atoi(parts[1])
+	if err != nil {
+		lineNum = 0
+	}
+
+	var col int
+	var message string
+
+	if len(parts) == 4 {
+		col, err = strconv.Atoi(parts[2])
+		if err != nil {
+			col = 0
+			message = strings.TrimSpace(parts[2] + ":" + parts[3])
+		} else {
+			message = strings.TrimSpace(parts[3])
+		}
+	} else {
+		message = strings.TrimSpace(parts[2])
+	}
+
+	category := classifyChange(message)
+	entity := extractEntity(message)
+
+	return BreakingChange{
+		File:           file,
+		Line:           lineNum,
+		Column:         col,
+		Category:       category,
+		Severity:       categorySeverity[category],
+		Description:    message,
+		AffectedEntity: entity,
+	}, nil
+}
+
+// classifyChange determines the ChangeCategory from the message text.
+func classifyChange(message string) ChangeCategory {
+	lower := strings.ToLower(message)
+
+	for _, p := range categoryPatterns {
+		if strings.Contains(lower, strings.ToLower(p.pattern)) {
+			return p.category
+		}
+	}
+
+	return CategoryUnknown
+}
+
+// extractEntity attempts to extract the affected proto entity name from the message.
+// buf messages typically contain quoted entity names like `"MyService.MyMethod"`.
+func extractEntity(message string) string {
+	start := strings.Index(message, "\"")
+	if start == -1 {
+		return ""
+	}
+	end := strings.Index(message[start+1:], "\"")
+	if end == -1 {
+		return ""
+	}
+	return message[start+1 : start+1+end]
+}
+
+// CountByCategory returns the number of changes per category.
+func (r *BreakingReport) CountByCategory() map[ChangeCategory]int {
+	counts := make(map[ChangeCategory]int)
+	for _, c := range r.Changes {
+		counts[c.Category]++
+	}
+	return counts
+}
+
+// CountBySeverity returns the number of changes per severity level.
+func (r *BreakingReport) CountBySeverity() map[Severity]int {
+	counts := make(map[Severity]int)
+	for _, c := range r.Changes {
+		counts[c.Severity]++
+	}
+	return counts
+}
+
+// HasHighSeverity returns true if any change has high severity.
+func (r *BreakingReport) HasHighSeverity() bool {
+	for _, c := range r.Changes {
+		if c.Severity == SeverityHigh {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/buf/parser_test.go
+++ b/internal/buf/parser_test.go
@@ -1,0 +1,187 @@
+package buf_test
+
+import (
+	"testing"
+
+	"github.com/akaitigo/grpc-contract-guardian/internal/buf"
+)
+
+func TestParseOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	report, err := buf.ParseOutput("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.TotalCount != 0 {
+		t.Errorf("expected 0 changes, got %d", report.TotalCount)
+	}
+}
+
+func TestParseOutput_SingleFieldRemoved(t *testing.T) {
+	t.Parallel()
+
+	input := `user/v1/user.proto:10:3:Previously present field "5" with name "email" on message "User" was deleted.`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.TotalCount != 1 {
+		t.Fatalf("expected 1 change, got %d", report.TotalCount)
+	}
+
+	c := report.Changes[0]
+	if c.File != "user/v1/user.proto" {
+		t.Errorf("file = %q, want %q", c.File, "user/v1/user.proto")
+	}
+	if c.Line != 10 {
+		t.Errorf("line = %d, want %d", c.Line, 10)
+	}
+	if c.Column != 3 {
+		t.Errorf("column = %d, want %d", c.Column, 3)
+	}
+	if c.Category != buf.CategoryFieldRemoved {
+		t.Errorf("category = %q, want %q", c.Category, buf.CategoryFieldRemoved)
+	}
+	if c.Severity != buf.SeverityHigh {
+		t.Errorf("severity = %q, want %q", c.Severity, buf.SeverityHigh)
+	}
+}
+
+func TestParseOutput_MultipleChanges(t *testing.T) {
+	t.Parallel()
+
+	input := `order/v1/order.proto:5:1:Previously present service "OrderService" was deleted.
+order/v1/order.proto:20:1:Previously present enum value "3" on enum "OrderStatus" was deleted.
+payment/v1/payment.proto:15:3:Previously present field "2" with name "amount" on message "Payment" was deleted.`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.TotalCount != 3 {
+		t.Fatalf("expected 3 changes, got %d", report.TotalCount)
+	}
+
+	if report.Changes[0].Category != buf.CategoryServiceRemoved {
+		t.Errorf("change[0] category = %q, want SERVICE_REMOVED", report.Changes[0].Category)
+	}
+	if report.Changes[1].Category != buf.CategoryEnumValueRemoved {
+		t.Errorf("change[1] category = %q, want ENUM_VALUE_REMOVED", report.Changes[1].Category)
+	}
+	if report.Changes[2].Category != buf.CategoryFieldRemoved {
+		t.Errorf("change[2] category = %q, want FIELD_REMOVED", report.Changes[2].Category)
+	}
+}
+
+func TestParseOutput_MethodSignatureChange(t *testing.T) {
+	t.Parallel()
+
+	input := `api/v1/api.proto:30:3:Method "GetUser" on service "UserService" changed request type from "GetUserRequest" to "GetUserRequestV2".`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.TotalCount != 1 {
+		t.Fatalf("expected 1 change, got %d", report.TotalCount)
+	}
+
+	if report.Changes[0].Category != buf.CategoryMethodSignatureChanged {
+		t.Errorf("category = %q, want METHOD_SIGNATURE_CHANGED", report.Changes[0].Category)
+	}
+}
+
+func TestParseOutput_EntityExtraction(t *testing.T) {
+	t.Parallel()
+
+	input := `user/v1/user.proto:10:3:Previously present field "5" with name "email" on message "User" was deleted.`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.Changes[0].AffectedEntity != "5" {
+		t.Errorf("entity = %q, want %q", report.Changes[0].AffectedEntity, "5")
+	}
+}
+
+func TestBreakingReport_CountByCategory(t *testing.T) {
+	t.Parallel()
+
+	report := &buf.BreakingReport{
+		Changes: []buf.BreakingChange{
+			{Category: buf.CategoryFieldRemoved},
+			{Category: buf.CategoryFieldRemoved},
+			{Category: buf.CategoryServiceRemoved},
+		},
+		TotalCount: 3,
+	}
+
+	counts := report.CountByCategory()
+	if counts[buf.CategoryFieldRemoved] != 2 {
+		t.Errorf("FIELD_REMOVED count = %d, want 2", counts[buf.CategoryFieldRemoved])
+	}
+	if counts[buf.CategoryServiceRemoved] != 1 {
+		t.Errorf("SERVICE_REMOVED count = %d, want 1", counts[buf.CategoryServiceRemoved])
+	}
+}
+
+func TestBreakingReport_CountBySeverity(t *testing.T) {
+	t.Parallel()
+
+	report := &buf.BreakingReport{
+		Changes: []buf.BreakingChange{
+			{Severity: buf.SeverityHigh},
+			{Severity: buf.SeverityHigh},
+			{Severity: buf.SeverityMedium},
+		},
+		TotalCount: 3,
+	}
+
+	counts := report.CountBySeverity()
+	if counts[buf.SeverityHigh] != 2 {
+		t.Errorf("high count = %d, want 2", counts[buf.SeverityHigh])
+	}
+}
+
+func TestBreakingReport_HasHighSeverity(t *testing.T) {
+	t.Parallel()
+
+	withHigh := &buf.BreakingReport{
+		Changes: []buf.BreakingChange{{Severity: buf.SeverityHigh}},
+	}
+	if !withHigh.HasHighSeverity() {
+		t.Error("expected HasHighSeverity() = true")
+	}
+
+	withoutHigh := &buf.BreakingReport{
+		Changes: []buf.BreakingChange{{Severity: buf.SeverityLow}},
+	}
+	if withoutHigh.HasHighSeverity() {
+		t.Error("expected HasHighSeverity() = false")
+	}
+}
+
+func TestParseOutput_SkipsEmptyLines(t *testing.T) {
+	t.Parallel()
+
+	input := `
+user/v1/user.proto:10:3:Previously present field "5" on message "User" was deleted.
+
+order/v1/order.proto:5:1:Previously present service "OrderService" was deleted.
+`
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.TotalCount != 2 {
+		t.Errorf("expected 2 changes, got %d", report.TotalCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Parse `buf breaking` text output into structured `BreakingReport`
- 10 change categories with severity classification (high/medium/low)
- Entity name extraction from quoted strings
- Helper methods: CountByCategory, CountBySeverity, HasHighSeverity
- Pattern matching with priority ordering (specific patterns before general)

Closes #3

## Test plan
- [x] `go test -v -race ./internal/buf/` — 9/9 pass
- [x] `go test -v -race ./...` — 20/20 pass (full suite)
- [x] Empty input → zero changes
- [x] Single field removal → correct category + severity
- [x] Multiple changes → all categories classified correctly
- [x] Method signature change → METHOD_SIGNATURE_CHANGED (not SERVICE_REMOVED)
- [x] Empty lines skipped