### PR TITLE
feat #2: proto analyzer + dependency graph builder

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -3,59 +3,225 @@
 // messages, and their field-level dependencies.
 package analyzer
 
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
 // ProtoFile represents a parsed .proto file with its services and messages.
 type ProtoFile struct {
-	// Path is the file path of the .proto file.
-	Path string
-	// Package is the proto package name (e.g., "myservice.v1").
-	Package string
-	// Services defined in this file.
+	Path     string
+	Package  string
 	Services []Service
-	// Messages defined in this file.
 	Messages []Message
+	Imports  []string
 }
 
 // Service represents a gRPC service definition.
 type Service struct {
-	// Name is the service name.
-	Name string
-	// Methods are the RPC methods defined in this service.
+	Name    string
 	Methods []Method
 }
 
 // Method represents an RPC method in a service.
 type Method struct {
-	// Name is the method name.
-	Name string
-	// InputType is the fully qualified input message type.
-	InputType string
-	// OutputType is the fully qualified output message type.
+	Name       string
+	InputType  string
 	OutputType string
 }
 
 // Message represents a protobuf message definition.
 type Message struct {
-	// Name is the message name.
-	Name string
-	// Fields are the fields defined in this message.
+	Name   string
 	Fields []Field
 }
 
 // Field represents a field in a protobuf message.
 type Field struct {
-	// Name is the field name.
-	Name string
-	// Number is the field number.
+	Name   string
 	Number int32
-	// Type is the field type (e.g., "string", "int32", or a message type reference).
-	Type string
+	Type   string
 }
 
+var (
+	packageRe = regexp.MustCompile(`^package\s+([\w.]+)\s*;`)
+	importRe  = regexp.MustCompile(`^import\s+"([^"]+)"\s*;`)
+	serviceRe = regexp.MustCompile(`^service\s+(\w+)\s*\{`)
+	rpcRe     = regexp.MustCompile(`^\s*rpc\s+(\w+)\s*\(\s*(\w+)\s*\)\s*returns\s*\(\s*([\w.]+)\s*\)`)
+	messageRe = regexp.MustCompile(`^message\s+(\w+)\s*\{`)
+	fieldRe   = regexp.MustCompile(`^\s*(repeated\s+)?(\w+(?:\.\w+)*)\s+(\w+)\s*=\s*(\d+)`)
+)
+
 // Analyze parses a .proto file and returns its structured representation.
-// Returns an error if the file cannot be read or parsed.
 func Analyze(path string) (*ProtoFile, error) {
-	// Placeholder: will be implemented with protocompile in Issue #2
-	return &ProtoFile{
-		Path: path,
-	}, nil
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+
+	pf := &ProtoFile{Path: path}
+	scanner := bufio.NewScanner(f)
+
+	var (
+		inService bool
+		inMessage bool
+		curSvc    *Service
+		curMsg    *Message
+		braceDepth int
+	)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "syntax") {
+			continue
+		}
+
+		// Package and import are top-level, parse before brace tracking
+		if m := packageRe.FindStringSubmatch(line); m != nil {
+			pf.Package = m[1]
+			continue
+		}
+
+		// Import
+		if m := importRe.FindStringSubmatch(line); m != nil {
+			pf.Imports = append(pf.Imports, m[1])
+			continue
+		}
+
+		// Track brace depth for nested scope
+		braceDepth += strings.Count(line, "{") - strings.Count(line, "}")
+
+		if braceDepth <= 0 {
+			if inService && curSvc != nil {
+				pf.Services = append(pf.Services, *curSvc)
+				curSvc = nil
+				inService = false
+			}
+			if inMessage && curMsg != nil {
+				pf.Messages = append(pf.Messages, *curMsg)
+				curMsg = nil
+				inMessage = false
+			}
+			braceDepth = 0
+			continue
+		}
+
+		// Service start
+		if !inService && !inMessage {
+			if m := serviceRe.FindStringSubmatch(line); m != nil {
+				inService = true
+				curSvc = &Service{Name: m[1]}
+				continue
+			}
+		}
+
+		// Message start
+		if !inService && !inMessage {
+			if m := messageRe.FindStringSubmatch(line); m != nil {
+				inMessage = true
+				curMsg = &Message{Name: m[1]}
+				continue
+			}
+		}
+
+		// RPC method inside service
+		if inService && curSvc != nil {
+			if m := rpcRe.FindStringSubmatch(line); m != nil {
+				curSvc.Methods = append(curSvc.Methods, Method{
+					Name:       m[1],
+					InputType:  m[2],
+					OutputType: m[3],
+				})
+				continue
+			}
+		}
+
+		// Field inside message
+		if inMessage && curMsg != nil {
+			if m := fieldRe.FindStringSubmatch(line); m != nil {
+				var num int32
+				if _, err := fmt.Sscanf(m[4], "%d", &num); err == nil {
+					curMsg.Fields = append(curMsg.Fields, Field{
+						Name:   m[3],
+						Number: num,
+						Type:   strings.TrimPrefix(m[2], "repeated "),
+					})
+				}
+				continue
+			}
+		}
+
+		// Closing brace for service/message
+		if line == "}" {
+			if inService && curSvc != nil {
+				pf.Services = append(pf.Services, *curSvc)
+				curSvc = nil
+				inService = false
+			}
+			if inMessage && curMsg != nil {
+				pf.Messages = append(pf.Messages, *curMsg)
+				curMsg = nil
+				inMessage = false
+			}
+		}
+	}
+
+	// Handle unclosed blocks at EOF
+	if curSvc != nil {
+		pf.Services = append(pf.Services, *curSvc)
+	}
+	if curMsg != nil {
+		pf.Messages = append(pf.Messages, *curMsg)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning %s: %w", path, err)
+	}
+
+	return pf, nil
+}
+
+// AnalyzeAll parses multiple .proto files and returns all results.
+func AnalyzeAll(paths []string) ([]*ProtoFile, error) {
+	var results []*ProtoFile
+	for _, p := range paths {
+		pf, err := Analyze(p)
+		if err != nil {
+			return nil, fmt.Errorf("analyzing %s: %w", p, err)
+		}
+		results = append(results, pf)
+	}
+	return results, nil
+}
+
+// MessageTypes returns a set of all message type names referenced as field types.
+func (pf *ProtoFile) MessageTypes() []string {
+	seen := make(map[string]bool)
+	var types []string
+	for _, msg := range pf.Messages {
+		for _, f := range msg.Fields {
+			if isMessageType(f.Type) && !seen[f.Type] {
+				seen[f.Type] = true
+				types = append(types, f.Type)
+			}
+		}
+	}
+	return types
+}
+
+// isMessageType returns true if the type name looks like a message reference
+// (starts with uppercase, not a primitive type).
+func isMessageType(t string) bool {
+	primitives := map[string]bool{
+		"double": true, "float": true, "int32": true, "int64": true,
+		"uint32": true, "uint64": true, "sint32": true, "sint64": true,
+		"fixed32": true, "fixed64": true, "sfixed32": true, "sfixed64": true,
+		"bool": true, "string": true, "bytes": true,
+	}
+	return !primitives[t] && len(t) > 0
 }

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -9,74 +9,152 @@ import (
 func TestAnalyze_ReturnsProtoFileWithPath(t *testing.T) {
 	t.Parallel()
 
-	path := "testdata/example.proto"
-	result, err := analyzer.Analyze(path)
+	result, err := analyzer.Analyze("../../testdata/user.proto")
 	if err != nil {
-		t.Fatalf("Analyze(%q) returned unexpected error: %v", path, err)
+		t.Fatalf("Analyze returned unexpected error: %v", err)
 	}
 
-	if result == nil {
-		t.Fatal("Analyze() returned nil")
-	}
-
-	if result.Path != path {
-		t.Errorf("Analyze(%q).Path = %q, want %q", path, result.Path, path)
+	if result.Path != "../../testdata/user.proto" {
+		t.Errorf("Path = %q, want testdata path", result.Path)
 	}
 }
 
-func TestProtoFile_StructFields(t *testing.T) {
+func TestAnalyze_Package(t *testing.T) {
 	t.Parallel()
 
-	pf := &analyzer.ProtoFile{
-		Path:    "test.proto",
-		Package: "example.v1",
-		Services: []analyzer.Service{
-			{
-				Name: "ExampleService",
-				Methods: []analyzer.Method{
-					{
-						Name:       "GetItem",
-						InputType:  "example.v1.GetItemRequest",
-						OutputType: "example.v1.GetItemResponse",
-					},
-				},
-			},
-		},
-		Messages: []analyzer.Message{
-			{
-				Name: "GetItemRequest",
-				Fields: []analyzer.Field{
-					{Name: "id", Number: 1, Type: "string"},
-				},
-			},
-		},
+	result, err := analyzer.Analyze("../../testdata/user.proto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(pf.Services) != 1 {
-		t.Fatalf("expected 1 service, got %d", len(pf.Services))
+	if result.Package != "example.user.v1" {
+		t.Errorf("Package = %q, want %q", result.Package, "example.user.v1")
+	}
+}
+
+func TestAnalyze_Services(t *testing.T) {
+	t.Parallel()
+
+	result, err := analyzer.Analyze("../../testdata/user.proto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if pf.Services[0].Name != "ExampleService" {
-		t.Errorf("service name = %q, want %q", pf.Services[0].Name, "ExampleService")
+	if len(result.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(result.Services))
 	}
 
-	if len(pf.Services[0].Methods) != 1 {
-		t.Fatalf("expected 1 method, got %d", len(pf.Services[0].Methods))
+	svc := result.Services[0]
+	if svc.Name != "UserService" {
+		t.Errorf("service name = %q, want %q", svc.Name, "UserService")
 	}
 
-	if pf.Services[0].Methods[0].Name != "GetItem" {
-		t.Errorf("method name = %q, want %q", pf.Services[0].Methods[0].Name, "GetItem")
+	if len(svc.Methods) != 2 {
+		t.Fatalf("expected 2 methods, got %d", len(svc.Methods))
 	}
 
-	if len(pf.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(pf.Messages))
+	if svc.Methods[0].Name != "GetUser" {
+		t.Errorf("method[0] = %q, want %q", svc.Methods[0].Name, "GetUser")
+	}
+	if svc.Methods[0].InputType != "GetUserRequest" {
+		t.Errorf("method[0].InputType = %q, want %q", svc.Methods[0].InputType, "GetUserRequest")
+	}
+	if svc.Methods[0].OutputType != "GetUserResponse" {
+		t.Errorf("method[0].OutputType = %q, want %q", svc.Methods[0].OutputType, "GetUserResponse")
+	}
+}
+
+func TestAnalyze_Messages(t *testing.T) {
+	t.Parallel()
+
+	result, err := analyzer.Analyze("../../testdata/user.proto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(pf.Messages[0].Fields) != 1 {
-		t.Fatalf("expected 1 field, got %d", len(pf.Messages[0].Fields))
+	// user.proto has: GetUserRequest, GetUserResponse, ListUsersRequest, ListUsersResponse, User, Address
+	if len(result.Messages) < 5 {
+		t.Fatalf("expected at least 5 messages, got %d", len(result.Messages))
 	}
 
-	if pf.Messages[0].Fields[0].Number != 1 {
-		t.Errorf("field number = %d, want %d", pf.Messages[0].Fields[0].Number, 1)
+	// Find User message
+	var userMsg *analyzer.Message
+	for i := range result.Messages {
+		if result.Messages[i].Name == "User" {
+			userMsg = &result.Messages[i]
+			break
+		}
+	}
+
+	if userMsg == nil {
+		t.Fatal("User message not found")
+	}
+
+	if len(userMsg.Fields) != 4 {
+		t.Fatalf("User fields: expected 4, got %d", len(userMsg.Fields))
+	}
+
+	// Check that Address field is detected as message type reference
+	var hasAddress bool
+	for _, f := range userMsg.Fields {
+		if f.Name == "address" && f.Type == "Address" {
+			hasAddress = true
+		}
+	}
+	if !hasAddress {
+		t.Error("User.address field with type Address not found")
+	}
+}
+
+func TestAnalyze_MessageTypes(t *testing.T) {
+	t.Parallel()
+
+	result, err := analyzer.Analyze("../../testdata/user.proto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	types := result.MessageTypes()
+	if len(types) == 0 {
+		t.Fatal("expected at least 1 message type reference")
+	}
+
+	var hasUser, hasAddress bool
+	for _, tt := range types {
+		if tt == "User" {
+			hasUser = true
+		}
+		if tt == "Address" {
+			hasAddress = true
+		}
+	}
+
+	if !hasUser {
+		t.Error("expected User in message types")
+	}
+	if !hasAddress {
+		t.Error("expected Address in message types")
+	}
+}
+
+func TestAnalyze_NonexistentFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := analyzer.Analyze("nonexistent.proto")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestAnalyzeAll(t *testing.T) {
+	t.Parallel()
+
+	results, err := analyzer.AnalyzeAll([]string{"../../testdata/user.proto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/akaitigo/grpc-contract-guardian/internal/analyzer"
 )
 
 // Node represents a node in the dependency graph.
@@ -104,4 +106,77 @@ func (g *DependencyGraph) WriteText(w io.Writer) error {
 		}
 	}
 	return nil
+}
+
+// BuildFromProtoFiles constructs a dependency graph from parsed proto files.
+func BuildFromProtoFiles(files []*analyzer.ProtoFile) *DependencyGraph {
+	g := NewGraph()
+
+	for _, pf := range files {
+		prefix := pf.Package
+		if prefix != "" {
+			prefix += "."
+		}
+
+		// Add message nodes
+		for _, msg := range pf.Messages {
+			g.AddNode(Node{
+				ID:    prefix + msg.Name,
+				Kind:  "message",
+				Label: msg.Name,
+			})
+
+			// Add edges for message-type fields
+			for _, f := range msg.Fields {
+				if isMessageType(f.Type) {
+					target := f.Type
+					if !strings.Contains(target, ".") {
+						target = prefix + target
+					}
+					g.AddEdge(Edge{
+						From:  prefix + msg.Name,
+						To:    target,
+						Label: "field:" + f.Name,
+					})
+				}
+			}
+		}
+
+		// Add service nodes and method edges
+		for _, svc := range pf.Services {
+			svcID := prefix + svc.Name
+			g.AddNode(Node{
+				ID:    svcID,
+				Kind:  "service",
+				Label: svc.Name,
+			})
+
+			for _, m := range svc.Methods {
+				inputID := m.InputType
+				if !strings.Contains(inputID, ".") {
+					inputID = prefix + inputID
+				}
+				outputID := m.OutputType
+				if !strings.Contains(outputID, ".") {
+					outputID = prefix + outputID
+				}
+
+				g.AddEdge(Edge{From: svcID, To: inputID, Label: "input:" + m.Name})
+				g.AddEdge(Edge{From: svcID, To: outputID, Label: "output:" + m.Name})
+			}
+		}
+	}
+
+	return g
+}
+
+// isMessageType returns true if the type is not a protobuf primitive.
+func isMessageType(t string) bool {
+	primitives := map[string]bool{
+		"double": true, "float": true, "int32": true, "int64": true,
+		"uint32": true, "uint64": true, "sint32": true, "sint64": true,
+		"fixed32": true, "fixed64": true, "sfixed32": true, "sfixed64": true,
+		"bool": true, "string": true, "bytes": true,
+	}
+	return !primitives[t] && len(t) > 0
 }

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/akaitigo/grpc-contract-guardian/internal/analyzer"
 	"github.com/akaitigo/grpc-contract-guardian/internal/graph"
 )
 
@@ -76,5 +77,79 @@ func TestWriteText(t *testing.T) {
 	}
 	if !strings.Contains(output, "UserService") {
 		t.Error("text output missing service name")
+	}
+}
+
+func TestBuildFromProtoFiles(t *testing.T) {
+	t.Parallel()
+
+	files := []*analyzer.ProtoFile{
+		{
+			Package: "example.v1",
+			Services: []analyzer.Service{
+				{
+					Name: "UserService",
+					Methods: []analyzer.Method{
+						{Name: "GetUser", InputType: "GetUserRequest", OutputType: "GetUserResponse"},
+					},
+				},
+			},
+			Messages: []analyzer.Message{
+				{Name: "GetUserRequest", Fields: []analyzer.Field{{Name: "id", Number: 1, Type: "string"}}},
+				{Name: "GetUserResponse", Fields: []analyzer.Field{{Name: "user", Number: 1, Type: "User"}}},
+				{Name: "User", Fields: []analyzer.Field{
+					{Name: "id", Number: 1, Type: "string"},
+					{Name: "name", Number: 2, Type: "string"},
+				}},
+			},
+		},
+	}
+
+	g := graph.BuildFromProtoFiles(files)
+
+	// Should have service + 3 messages = 4 nodes
+	if len(g.Nodes) < 4 {
+		t.Errorf("expected at least 4 nodes, got %d", len(g.Nodes))
+	}
+
+	// Should have edges: service→input, service→output, GetUserResponse→User
+	if len(g.Edges) < 3 {
+		t.Errorf("expected at least 3 edges, got %d", len(g.Edges))
+	}
+
+	// Verify DOT output works
+	var buf bytes.Buffer
+	if err := g.WriteDOT(&buf); err != nil {
+		t.Fatalf("WriteDOT error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "UserService") {
+		t.Error("DOT output missing UserService")
+	}
+}
+
+func TestBuildFromProtoFiles_Integration(t *testing.T) {
+	t.Parallel()
+
+	pf, err := analyzer.Analyze("../../testdata/user.proto")
+	if err != nil {
+		t.Fatalf("Analyze error: %v", err)
+	}
+
+	g := graph.BuildFromProtoFiles([]*analyzer.ProtoFile{pf})
+
+	if len(g.Nodes) == 0 {
+		t.Fatal("expected nodes from user.proto")
+	}
+	if len(g.Edges) == 0 {
+		t.Fatal("expected edges from user.proto")
+	}
+
+	// Verify text output has the service
+	var buf bytes.Buffer
+	if err := g.WriteText(&buf); err != nil {
+		t.Fatalf("WriteText error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "UserService") {
+		t.Error("text output missing UserService from integration test")
 	}
 }

--- a/testdata/user.proto
+++ b/testdata/user.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package example.user.v1;
+
+service UserService {
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
+}
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message GetUserResponse {
+  User user = 1;
+}
+
+message ListUsersRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+}
+
+message ListUsersResponse {
+  repeated User users = 1;
+  string next_page_token = 2;
+}
+
+message User {
+  string id = 1;
+  string name = 2;
+  string email = 3;
+  Address address = 4;
+}
+
+message Address {
+  string street = 1;
+  string city = 2;
+  string country = 3;
+}


### PR DESCRIPTION
## Summary
- Regex-based .proto file parser (package, services, messages, fields)
- Dependency graph construction from parsed proto files
- Service→Message and Message→Message edges
- testdata/user.proto for integration testing

Closes #2

## Test plan
- [x] `go test -v -race ./...` — 28/28 pass
- [x] Package extraction from proto files
- [x] Service/method/message/field parsing
- [x] Message type reference detection
- [x] Graph construction with DOT and text output
- [x] Integration test with real .proto file