### PR TITLE
feat #5: cobra CLI — check + graph + version

### DIFF
--- a/cmd/guardian/check.go
+++ b/cmd/guardian/check.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/akaitigo/grpc-contract-guardian/internal/analyzer"
+	"github.com/akaitigo/grpc-contract-guardian/internal/buf"
+	"github.com/akaitigo/grpc-contract-guardian/internal/graph"
+	"github.com/akaitigo/grpc-contract-guardian/internal/reporter"
+	"github.com/spf13/cobra"
+)
+
+func newCheckCmd() *cobra.Command {
+	var (
+		against   string
+		format    string
+		prNumber  int
+		repo      string
+		protoRoot string
+		dryRun    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Run breaking change detection and show impact",
+		Long:  "Runs buf breaking against the specified ref, analyzes the dependency graph, and reports the impact of breaking changes.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// 1. Run buf breaking
+			bufOutput, err := runBufBreaking(against, protoRoot)
+			if err != nil {
+				return fmt.Errorf("buf breaking: %w", err)
+			}
+
+			// 2. Parse breaking changes
+			breakingReport, err := buf.ParseOutput(bufOutput)
+			if err != nil {
+				return fmt.Errorf("parsing buf output: %w", err)
+			}
+
+			// 3. Analyze proto files for dependency graph
+			protoFiles, err := findProtoFiles(protoRoot)
+			if err != nil {
+				return fmt.Errorf("finding proto files: %w", err)
+			}
+
+			parsed, err := analyzer.AnalyzeAll(protoFiles)
+			if err != nil {
+				return fmt.Errorf("analyzing proto files: %w", err)
+			}
+
+			g := graph.BuildFromProtoFiles(parsed)
+
+			// 4. Generate impact report
+			impactReport := reporter.AnalyzeImpact(breakingReport, g)
+
+			// 5. Output
+			switch format {
+			case "text":
+				return reporter.WriteImpactText(os.Stdout, impactReport)
+			case "github":
+				if prNumber == 0 {
+					return fmt.Errorf("--pr is required for github format")
+				}
+				parts := strings.SplitN(repo, "/", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("--repo must be owner/repo format")
+				}
+				body, err := reporter.PostToGitHubPR(impactReport, parts[0], parts[1], prNumber, dryRun)
+				if err != nil {
+					return err
+				}
+				if dryRun {
+					fmt.Print(body)
+				} else {
+					fmt.Fprintf(os.Stderr, "Posted impact report to PR #%d\n", prNumber)
+				}
+				return nil
+			default:
+				return fmt.Errorf("unsupported format: %s", format)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&against, "against", "main", "Git ref to compare against")
+	cmd.Flags().StringVar(&format, "format", "text", "Output format: text, github")
+	cmd.Flags().IntVar(&prNumber, "pr", 0, "GitHub PR number (required for github format)")
+	cmd.Flags().StringVar(&repo, "repo", "", "GitHub repository (owner/repo)")
+	cmd.Flags().StringVar(&protoRoot, "proto-root", ".", "Root directory for .proto files")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print output without posting to GitHub")
+
+	return cmd
+}
+
+func runBufBreaking(against, protoRoot string) (string, error) {
+	cmd := exec.Command("buf", "breaking", protoRoot, "--against", fmt.Sprintf(".git#branch=%s", against))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// buf breaking returns exit code 1 when breaking changes are found
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return string(out), nil
+		}
+		// buf not installed or other error
+		if strings.Contains(string(out), "not found") || strings.Contains(err.Error(), "not found") {
+			return "", fmt.Errorf("buf is not installed. Install from https://buf.build/docs/installation")
+		}
+		return string(out), nil
+	}
+	return string(out), nil
+}
+
+func findProtoFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".proto") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
+}

--- a/cmd/guardian/graph_cmd.go
+++ b/cmd/guardian/graph_cmd.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/akaitigo/grpc-contract-guardian/internal/analyzer"
+	"github.com/akaitigo/grpc-contract-guardian/internal/graph"
+	"github.com/spf13/cobra"
+)
+
+func newGraphCmd() *cobra.Command {
+	var (
+		output    string
+		protoRoot string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "graph",
+		Short: "Output service dependency graph",
+		Long:  "Analyzes .proto files and outputs the service dependency graph in DOT or text format.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			protoFiles, err := findProtoFiles(protoRoot)
+			if err != nil {
+				return fmt.Errorf("finding proto files: %w", err)
+			}
+
+			if len(protoFiles) == 0 {
+				return fmt.Errorf("no .proto files found in %s", protoRoot)
+			}
+
+			parsed, err := analyzer.AnalyzeAll(protoFiles)
+			if err != nil {
+				return fmt.Errorf("analyzing proto files: %w", err)
+			}
+
+			g := graph.BuildFromProtoFiles(parsed)
+
+			switch output {
+			case "text":
+				return g.WriteText(os.Stdout)
+			case "dot":
+				return g.WriteDOT(os.Stdout)
+			default:
+				return fmt.Errorf("unsupported output format: %s (use text or dot)", output)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&output, "output", "text", "Output format: text, dot")
+	cmd.Flags().StringVar(&protoRoot, "proto-root", ".", "Root directory for .proto files")
+
+	return cmd
+}

--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -1,29 +1,45 @@
-// Package main is the entry point for the grpc-contract-guardian CLI.
-// guardian analyzes .proto files for backward compatibility and visualizes
-// the impact of breaking changes across service dependencies.
 package main
 
 import (
 	"fmt"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
-// version is set at build time via -ldflags.
 var version = "dev"
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "--version" {
-		fmt.Printf("guardian %s\n", version)
-		return
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "guardian",
+		Short: "gRPC/Proto backward compatibility checker + impact visualizer",
+		Long:  "guardian analyzes .proto files for backward compatibility and visualizes the impact of breaking changes across service dependencies.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
-	fmt.Fprintln(os.Stderr, "grpc-contract-guardian: proto backward compatibility checker + impact visualizer")
-	fmt.Fprintln(os.Stderr, "Usage: guardian <command> [flags]")
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "Commands:")
-	fmt.Fprintln(os.Stderr, "  check   Run breaking change detection and show impact")
-	fmt.Fprintln(os.Stderr, "  graph   Output service dependency graph")
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "Use \"guardian <command> --help\" for more information about a command.")
-	os.Exit(1)
+	root.AddCommand(newCheckCmd())
+	root.AddCommand(newGraphCmd())
+	root.AddCommand(newVersionCmd())
+
+	return root
+}
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print guardian version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("guardian %s\n", version)
+		},
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/akaitigo/grpc-contract-guardian
 
 go 1.23
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -1,9 +1,4 @@
 #!/usr/bin/env bats
-# =============================================================================
-# grpc-contract-guardian CLI E2E テスト（bats-core）
-# =============================================================================
-
-# --- セットアップ ---
 
 setup() {
     TOOL="./bin/guardian"
@@ -14,37 +9,55 @@ teardown() {
     rm -rf "$TEST_TEMP"
 }
 
-# --- ヘルプ・バージョン ---
-
-@test "--version でバージョンが表示される" {
-    run "$TOOL" --version
+@test "version コマンドでバージョンが表示される" {
+    run "$TOOL" version
     [ "$status" -eq 0 ]
     [[ "$output" == *"guardian"* ]]
 }
 
-# --- 引数バリデーション ---
-
-@test "引数なしで実行するとusageが表示され終了コード1" {
-    run "$TOOL"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"Usage"* ]]
-}
-
-# --- 出力制御 ---
-
-@test "エラーメッセージがstderrに出力される" {
-    run "$TOOL" 2>&1
-    [ "$status" -eq 1 ]
-}
-
-# --- コマンド一覧 ---
-
-@test "usageにcheckコマンドが含まれる" {
-    run "$TOOL" 2>&1
+@test "--help でusageが表示される" {
+    run "$TOOL" --help
+    [ "$status" -eq 0 ]
     [[ "$output" == *"check"* ]]
+    [[ "$output" == *"graph"* ]]
+    [[ "$output" == *"version"* ]]
 }
 
-@test "usageにgraphコマンドが含まれる" {
-    run "$TOOL" 2>&1
-    [[ "$output" == *"graph"* ]]
+@test "check --help でフラグ一覧が表示される" {
+    run "$TOOL" check --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--against"* ]]
+    [[ "$output" == *"--format"* ]]
+    [[ "$output" == *"--pr"* ]]
+    [[ "$output" == *"--proto-root"* ]]
+}
+
+@test "graph --help でフラグ一覧が表示される" {
+    run "$TOOL" graph --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--output"* ]]
+    [[ "$output" == *"--proto-root"* ]]
+}
+
+@test "graph --output text でtestdataのグラフが出力される" {
+    run "$TOOL" graph --proto-root testdata --output text
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"UserService"* ]]
+}
+
+@test "graph --output dot でDOT形式が出力される" {
+    run "$TOOL" graph --proto-root testdata --output dot
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"digraph"* ]]
+    [[ "$output" == *"UserService"* ]]
+}
+
+@test "graph --output invalid でエラーが返る" {
+    run "$TOOL" graph --proto-root testdata --output invalid
+    [ "$status" -ne 0 ]
+}
+
+@test "存在しないサブコマンドでエラー" {
+    run "$TOOL" nonexistent
+    [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Summary
- cobra-based CLI: `check`, `graph`, `version` subcommands
- `guardian check --against main --format github --pr N --repo owner/repo`
- `guardian graph --proto-root testdata --output dot|text`
- 8 bats E2E tests

Closes #5

## Test plan
- [x] `go test -race ./...` — all pass
- [x] `make build` — binary builds
- [x] `guardian --help` — shows check/graph/version
- [x] `guardian graph --proto-root testdata --output text` — shows UserService graph
- [x] `guardian graph --proto-root testdata --output dot` — valid DOT output
- [x] `guardian version` — shows version