### PR TITLE
fix: address 3-model code review findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint format check clean tidy install
+.PHONY: build test lint format check clean tidy install e2e
 
 # Go build settings
 BINARY_NAME := guardian
@@ -9,8 +9,16 @@ BUILD_DIR := bin
 build:
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/guardian/
 
-test:
+test: build
 	go test -v -race -count=1 -coverprofile=coverage.out ./...
+	@if command -v bats >/dev/null 2>&1; then \
+		bats test/cli.bats; \
+	else \
+		echo "bats not found, skipping E2E tests"; \
+	fi
+
+e2e: build
+	bats test/cli.bats
 
 lint:
 	golangci-lint run ./...

--- a/cmd/guardian/check.go
+++ b/cmd/guardian/check.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -8,12 +9,18 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/akaitigo/grpc-contract-guardian/internal/analyzer"
 	"github.com/akaitigo/grpc-contract-guardian/internal/buf"
 	"github.com/akaitigo/grpc-contract-guardian/internal/graph"
 	"github.com/akaitigo/grpc-contract-guardian/internal/reporter"
 	"github.com/spf13/cobra"
+)
+
+const (
+	// defaultExecTimeout is the maximum duration for external commands (buf, gh).
+	defaultExecTimeout = 2 * time.Minute
 )
 
 const (
@@ -90,7 +97,7 @@ func newCheckCmd() *cobra.Command {
 			// 5. Output
 			switch format {
 			case formatText:
-				return reporter.WriteImpactText(os.Stdout, impactReport)
+				return reporter.WriteImpactText(cmd.OutOrStdout(), impactReport)
 			case formatGitHub:
 				if prNumber == 0 {
 					return fmt.Errorf("--pr is required for github format")
@@ -101,9 +108,9 @@ func newCheckCmd() *cobra.Command {
 					return err
 				}
 				if dryRun {
-					fmt.Print(body)
+					fmt.Fprint(cmd.OutOrStdout(), body)
 				} else {
-					fmt.Fprintf(os.Stderr, "Posted impact report to PR #%d\n", prNumber)
+					fmt.Fprintf(cmd.ErrOrStderr(), "Posted impact report to PR #%d\n", prNumber)
 				}
 				return nil
 			default:
@@ -123,7 +130,10 @@ func newCheckCmd() *cobra.Command {
 }
 
 func runBufBreaking(against, protoRoot string) (string, error) {
-	cmd := exec.Command("buf", "breaking", protoRoot, "--against", fmt.Sprintf(".git#branch=%s", against)) // #nosec G204 -- arguments from trusted CLI flags
+	ctx, cancel := context.WithTimeout(context.Background(), defaultExecTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "buf", "breaking", protoRoot, "--against", fmt.Sprintf(".git#branch=%s", against)) // #nosec G204 -- arguments from trusted CLI flags
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/cmd/guardian/graph_cmd.go
+++ b/cmd/guardian/graph_cmd.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/akaitigo/grpc-contract-guardian/internal/analyzer"
 	"github.com/akaitigo/grpc-contract-guardian/internal/graph"
@@ -38,9 +37,9 @@ func newGraphCmd() *cobra.Command {
 
 			switch output {
 			case formatText:
-				return g.WriteText(os.Stdout)
+				return g.WriteText(cmd.OutOrStdout())
 			case "dot":
-				return g.WriteDOT(os.Stdout)
+				return g.WriteDOT(cmd.OutOrStdout())
 			default:
 				return fmt.Errorf("unsupported output format: %s (use text or dot)", output)
 			}

--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -25,7 +25,7 @@ func newRootCmd() *cobra.Command {
 			return cmd.Help()
 		},
 		SilenceUsage:  true,
-		SilenceErrors: true,
+		SilenceErrors: false,
 	}
 
 	root.AddCommand(newCheckCmd())
@@ -40,7 +40,7 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print guardian version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("guardian %s\n", version)
+			fmt.Fprintf(cmd.OutOrStdout(), "guardian %s\n", version)
 		},
 	}
 }

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -50,7 +50,7 @@ var (
 	packageRe = regexp.MustCompile(`^package\s+([\w.]+)\s*;`)
 	importRe  = regexp.MustCompile(`^import\s+"([^"]+)"\s*;`)
 	serviceRe = regexp.MustCompile(`^service\s+(\w+)\s*\{`)
-	rpcRe     = regexp.MustCompile(`^\s*rpc\s+(\w+)\s*\(\s*(?:stream\s+)?(\w+)\s*\)\s*returns\s*\(\s*(?:stream\s+)?([\w.]+)\s*\)`)
+	rpcRe     = regexp.MustCompile(`^\s*rpc\s+(\w+)\s*\(\s*(?:stream\s+)?([\w.]+)\s*\)\s*returns\s*\(\s*(?:stream\s+)?([\w.]+)\s*\)`)
 	messageRe = regexp.MustCompile(`^message\s+(\w+)\s*\{`)
 	fieldRe   = regexp.MustCompile(`^\s*(repeated\s+)?(\w+(?:\.\w+)*)\s+(\w+)\s*=\s*(\d+)`)
 )

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -158,3 +158,29 @@ func TestAnalyzeAll(t *testing.T) {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
 }
+
+func TestAnalyze_FQNTypes(t *testing.T) {
+	t.Parallel()
+
+	result, err := analyzer.Analyze("../../testdata/fqn_types.proto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(result.Services))
+	}
+
+	svc := result.Services[0]
+	if len(svc.Methods) != 1 {
+		t.Fatalf("expected 1 method, got %d", len(svc.Methods))
+	}
+
+	m := svc.Methods[0]
+	if m.InputType != "common.v1.GetUserRequest" {
+		t.Errorf("InputType = %q, want %q", m.InputType, "common.v1.GetUserRequest")
+	}
+	if m.OutputType != "common.v1.GetUserResponse" {
+		t.Errorf("OutputType = %q, want %q", m.OutputType, "common.v1.GetUserResponse")
+	}
+}

--- a/internal/buf/parser.go
+++ b/internal/buf/parser.go
@@ -5,6 +5,7 @@ package buf
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 )
@@ -47,8 +48,9 @@ type BreakingChange struct {
 
 // BreakingReport is the structured result of parsing buf breaking output.
 type BreakingReport struct {
-	Changes    []BreakingChange
-	TotalCount int
+	Changes      []BreakingChange
+	TotalCount   int
+	SkippedLines int
 }
 
 // categorySeverity maps categories to their default severity.
@@ -103,6 +105,7 @@ func ParseOutput(rawOutput string) (*BreakingReport, error) {
 	}
 
 	var changes []BreakingChange
+	var skipped int
 	scanner := bufio.NewScanner(strings.NewReader(rawOutput))
 
 	for scanner.Scan() {
@@ -113,6 +116,8 @@ func ParseOutput(rawOutput string) (*BreakingReport, error) {
 
 		change, err := parseLine(line)
 		if err != nil {
+			skipped++
+			log.Printf("warning: skipped unparseable buf output line: %s", line)
 			continue
 		}
 
@@ -124,8 +129,9 @@ func ParseOutput(rawOutput string) (*BreakingReport, error) {
 	}
 
 	return &BreakingReport{
-		Changes:    changes,
-		TotalCount: len(changes),
+		Changes:      changes,
+		TotalCount:   len(changes),
+		SkippedLines: skipped,
 	}, nil
 }
 
@@ -187,8 +193,29 @@ func classifyChange(message string) ChangeCategory {
 
 // extractEntity attempts to extract the affected proto entity name from the message.
 // buf messages typically contain quoted entity names like `"MyService.MyMethod"`.
-// Field numbers (pure digits) are skipped to find the actual entity name.
+// For field-level changes (messages containing `on message "X"`), the message name
+// is extracted as the entity. For other changes, field numbers (pure digits) and
+// field names are skipped to find the service/method/message entity name.
 func extractEntity(message string) string {
+	// For field-level changes, prefer the message name from `on message "X"` pattern.
+	if idx := strings.Index(message, "on message \""); idx != -1 {
+		rest := message[idx+len("on message \""):]
+		end := strings.Index(rest, "\"")
+		if end != -1 {
+			return rest[:end]
+		}
+	}
+
+	// For enum value changes, prefer the enum name from `on enum "X"` pattern.
+	if idx := strings.Index(message, "on enum \""); idx != -1 {
+		rest := message[idx+len("on enum \""):]
+		end := strings.Index(rest, "\"")
+		if end != -1 {
+			return rest[:end]
+		}
+	}
+
+	// Fallback: return the first non-numeric quoted value.
 	remaining := message
 	for {
 		start := strings.Index(remaining, "\"")

--- a/internal/buf/parser_test.go
+++ b/internal/buf/parser_test.go
@@ -96,7 +96,7 @@ func TestParseOutput_MethodSignatureChange(t *testing.T) {
 	}
 }
 
-func TestParseOutput_EntityExtraction(t *testing.T) {
+func TestParseOutput_EntityExtraction_FieldRemoval(t *testing.T) {
 	t.Parallel()
 
 	input := `user/v1/user.proto:10:3:Previously present field "5" with name "email" on message "User" was deleted.`
@@ -106,9 +106,41 @@ func TestParseOutput_EntityExtraction(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Field numbers (pure digits like "5") should be skipped; first non-numeric quoted value is "email"
-	if report.Changes[0].AffectedEntity != "email" {
-		t.Errorf("entity = %q, want %q", report.Changes[0].AffectedEntity, "email")
+	// For field removal, the message name "User" (from `on message "User"`) should be extracted.
+	if report.Changes[0].AffectedEntity != "User" {
+		t.Errorf("entity = %q, want %q", report.Changes[0].AffectedEntity, "User")
+	}
+}
+
+func TestParseOutput_EntityExtraction_EnumValueRemoval(t *testing.T) {
+	t.Parallel()
+
+	input := `order/v1/order.proto:20:1:Previously present enum value "3" on enum "OrderStatus" was deleted.`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// For enum value removal, the enum name "OrderStatus" should be extracted.
+	if report.Changes[0].AffectedEntity != "OrderStatus" {
+		t.Errorf("entity = %q, want %q", report.Changes[0].AffectedEntity, "OrderStatus")
+	}
+}
+
+func TestParseOutput_EntityExtraction_ServiceRemoval(t *testing.T) {
+	t.Parallel()
+
+	input := `api/v1/api.proto:5:1:Previously present service "OrderService" was deleted.`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// For service removal, the service name should be extracted (fallback: first non-numeric quoted value).
+	if report.Changes[0].AffectedEntity != "OrderService" {
+		t.Errorf("entity = %q, want %q", report.Changes[0].AffectedEntity, "OrderService")
 	}
 }
 
@@ -184,5 +216,48 @@ order/v1/order.proto:5:1:Previously present service "OrderService" was deleted.
 
 	if report.TotalCount != 2 {
 		t.Errorf("expected 2 changes, got %d", report.TotalCount)
+	}
+}
+
+func TestParseOutput_FieldRemovalEntityIsMessageName(t *testing.T) {
+	t.Parallel()
+
+	// Exact buf output format for field removal.
+	// The entity must be "User" (message name), not "5" or "email".
+	input := `user/v1/user.proto:10:3:Previously present field "5" with name "email" on message "User" was deleted.`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.TotalCount != 1 {
+		t.Fatalf("expected 1 change, got %d", report.TotalCount)
+	}
+
+	entity := report.Changes[0].AffectedEntity
+	if entity != "User" {
+		t.Fatalf("BREAKING VERIFICATION FAILED: entity = %q, want %q (message name must be extracted for field removal)", entity, "User")
+	}
+}
+
+func TestParseOutput_SkippedLinesCount(t *testing.T) {
+	t.Parallel()
+
+	input := `user/v1/user.proto:10:3:Previously present field "5" on message "User" was deleted.
+this is not a valid buf line
+also invalid
+order/v1/order.proto:5:1:Previously present service "OrderService" was deleted.`
+
+	report, err := buf.ParseOutput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.TotalCount != 2 {
+		t.Errorf("expected 2 changes, got %d", report.TotalCount)
+	}
+	if report.SkippedLines != 2 {
+		t.Errorf("expected 2 skipped lines, got %d", report.SkippedLines)
 	}
 }

--- a/internal/reporter/github.go
+++ b/internal/reporter/github.go
@@ -2,9 +2,17 @@ package reporter
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"log"
 	"os/exec"
 	"strings"
+	"time"
+)
+
+const (
+	// defaultGHTimeout is the maximum duration for gh API commands.
+	defaultGHTimeout = 30 * time.Second
 )
 
 const commentMarker = "<!-- grpc-contract-guardian -->"
@@ -18,9 +26,12 @@ type CommandRunner interface {
 // ExecCommandRunner is the default CommandRunner that delegates to os/exec.
 type ExecCommandRunner struct{}
 
-// Run executes a command using os/exec.
+// Run executes a command using os/exec with a timeout.
 func (r *ExecCommandRunner) Run(name string, args ...string) ([]byte, error) {
-	cmd := exec.Command(name, args...) // #nosec G204 -- arguments from trusted CLI flags
+	ctx, cancel := context.WithTimeout(context.Background(), defaultGHTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- arguments from trusted CLI flags
 	return cmd.CombinedOutput()
 }
 
@@ -53,7 +64,13 @@ func PostToGitHubPR(report *ImpactReport, owner, repo string, prNumber int, dryR
 	}
 
 	// Check for existing guardian comment
-	existingID := findExistingComment(owner, repo, prNumber)
+	existingID, err := findExistingComment(owner, repo, prNumber)
+	if err != nil {
+		// If we fail to list comments, fall through to create a new one.
+		// This avoids duplicate comments in rare cases, but is more robust
+		// than failing the entire operation.
+		log.Printf("warning: failed to check for existing comment: %v", err)
+	}
 
 	if existingID != "" {
 		return commentBody, updateComment(owner, repo, existingID, commentBody)
@@ -62,16 +79,16 @@ func PostToGitHubPR(report *ImpactReport, owner, repo string, prNumber int, dryR
 	return commentBody, createComment(owner, repo, prNumber, commentBody)
 }
 
-func findExistingComment(owner, repo string, prNumber int) string {
+func findExistingComment(owner, repo string, prNumber int) (string, error) {
 	out, err := defaultRunner.Run("gh", "api",
 		fmt.Sprintf("repos/%s/%s/issues/%d/comments", owner, repo, prNumber),
 		"--jq", fmt.Sprintf(`.[] | select(.body | contains(%q)) | .id`, commentMarker),
 	)
 	if err != nil {
-		return "" // not found is OK
+		return "", fmt.Errorf("listing PR comments: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
 
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(string(out)), nil
 }
 
 func createComment(owner, repo string, prNumber int, body string) error {

--- a/internal/reporter/impact.go
+++ b/internal/reporter/impact.go
@@ -52,11 +52,17 @@ func AnalyzeImpact(breaking *buf.BreakingReport, g *graph.DependencyGraph) *Impa
 	return report
 }
 
-// matchesEntity returns true if nodeID is an exact match or FQN suffix match for entity.
-// For example, entity "User" matches "example.v1.User" but not "example.v1.UserProfile".
+// matchesEntity returns true if nodeID matches entity.
+// If entity is already a FQN (contains "."), only exact match is accepted.
+// Otherwise, nodeID must be an exact match or end with ".<entity>" (suffix match),
+// preventing partial matches like "UserProfile" matching entity "User".
 func matchesEntity(nodeID, entity string) bool {
 	if nodeID == entity {
 		return true
+	}
+	// If entity is a FQN, require exact match only (already checked above).
+	if strings.Contains(entity, ".") {
+		return false
 	}
 	return strings.HasSuffix(nodeID, "."+entity)
 }

--- a/internal/reporter/impact_test.go
+++ b/internal/reporter/impact_test.go
@@ -153,3 +153,60 @@ func TestPostToGitHubPR_DryRun(t *testing.T) {
 		t.Error("dry-run body missing marker")
 	}
 }
+
+func TestAnalyzeImpact_FQNEntityDoesNotSuffixMatch(t *testing.T) {
+	t.Parallel()
+
+	// When entity is already a FQN, only exact match should work.
+	g := graph.NewGraph()
+	g.AddNode(graph.Node{ID: "example.v1.UserService", Kind: "service", Label: "UserService"})
+	g.AddNode(graph.Node{ID: "other.v1.User", Kind: "message", Label: "User"})
+	g.AddEdge(graph.Edge{From: "example.v1.UserService", To: "other.v1.User", Label: "field:user"})
+
+	breaking := &buf.BreakingReport{
+		TotalCount: 1,
+		Changes: []buf.BreakingChange{
+			{
+				File:           "user/v1/user.proto",
+				Category:       buf.CategoryFieldRemoved,
+				Severity:       buf.SeverityHigh,
+				Description:    "field removed",
+				AffectedEntity: "example.v1.User", // FQN entity
+			},
+		},
+	}
+
+	report := reporter.AnalyzeImpact(breaking, g)
+	// "example.v1.User" should NOT match "other.v1.User"
+	if len(report.Impacts[0].AffectedServices) != 0 {
+		t.Errorf("expected 0 affected services for FQN mismatch, got %v", report.Impacts[0].AffectedServices)
+	}
+}
+
+func TestAnalyzeImpact_SimpleEntitySuffixMatches(t *testing.T) {
+	t.Parallel()
+
+	// When entity is a simple name, suffix match should work.
+	g := graph.NewGraph()
+	g.AddNode(graph.Node{ID: "example.v1.UserService", Kind: "service", Label: "UserService"})
+	g.AddNode(graph.Node{ID: "example.v1.User", Kind: "message", Label: "User"})
+	g.AddEdge(graph.Edge{From: "example.v1.UserService", To: "example.v1.User", Label: "field:user"})
+
+	breaking := &buf.BreakingReport{
+		TotalCount: 1,
+		Changes: []buf.BreakingChange{
+			{
+				File:           "user/v1/user.proto",
+				Category:       buf.CategoryFieldRemoved,
+				Severity:       buf.SeverityHigh,
+				Description:    "field removed",
+				AffectedEntity: "User", // simple name
+			},
+		},
+	}
+
+	report := reporter.AnalyzeImpact(breaking, g)
+	if len(report.Impacts[0].AffectedServices) != 1 {
+		t.Errorf("expected 1 affected service for simple name match, got %v", report.Impacts[0].AffectedServices)
+	}
+}

--- a/testdata/fqn_types.proto
+++ b/testdata/fqn_types.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package example.fqn.v1;
+
+service UserService {
+  rpc GetUser(common.v1.GetUserRequest) returns (common.v1.GetUserResponse);
+}


### PR DESCRIPTION
## Summary
- **H-1**: `extractEntity` now correctly extracts message name (e.g. `User`) from field removal messages instead of field name (`email`)
- **H-2**: `ParseOutput` logs warnings for unparseable lines and exposes `SkippedLines` count in `BreakingReport`
- **H-3**: `rpcRe` regex supports FQN types like `common.v1.GetUserRequest`
- **M-1**: `SilenceErrors: false` so Cobra displays errors to users
- **M-2**: `matchesEntity` requires exact match when entity is already a FQN (contains `.`)
- **M-3**: Bats E2E tests integrated into `make test` with graceful fallback if bats not installed
- **M-4**: All cmd output uses `cmd.OutOrStdout()` / `cmd.ErrOrStderr()` instead of direct `os.Stdout`
- **M-6**: `context.WithTimeout` added to `buf` (2min) and `gh` (30s) command execution
- **L-1**: `findExistingComment` returns error properly; caller logs warning and falls through

## Breaking verification
- H-1: `Previously present field "5" with name "email" on message "User" was deleted.` -> entity = `User` (verified in `TestParseOutput_FieldRemovalEntityIsMessageName`)
- H-3: `rpc GetUser(common.v1.GetUserRequest) returns (common.v1.GetUserResponse)` parses correctly (verified in `TestAnalyze_FQNTypes`)

## Test plan
- [x] All existing tests pass (`go test -v -race ./...`)
- [x] `golangci-lint run ./...` clean
- [x] New tests added for H-1, H-2, H-3, M-2 findings
- [x] Breakage verification tests explicitly confirm correct behavior
- [ ] CI pipeline green