### PR TITLE
chore: migrate golangci-lint to v2 (ADR-003)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.8
+          version: v2.12.2
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,135 +1,122 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
 output:
   formats:
-    - format: colored-line-number
-  sort-results: true
-
+    text:
+      path: stdout
 linters:
   enable:
-    # バグ検出
     - bodyclose
     - copyloopvar
+    - cyclop
     - durationcheck
-    - errcheck
-    - govet
-    - nilerr
-    - noctx
-    - rowserrcheck
-    - sqlclosecheck
-    - staticcheck
-    - typecheck
-
-    # スタイル・可読性
     - errname
-    - gofumpt
-    - goimports
+    - gocognit
     - goconst
     - gocritic
-    - gosimple
+    - gosec
     - misspell
     - nakedret
+    - nestif
+    - nilerr
+    - noctx
     - prealloc
     - predeclared
     - revive
-    - stylecheck
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - tparallel
     - unconvert
     - unparam
-    - unused
-    - whitespace
-
-    # セキュリティ
-    - gosec
-
-    # パフォーマンス
-    - ineffassign
-
-    # 複雑度
-    - cyclop
-    - gocognit
-    - nestif
-
-    # テスト
     - usetesting
-    - tparallel
-
-linters-settings:
-  cyclop:
-    max-complexity: 15
-
-  gocognit:
-    min-complexity: 20
-
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-
-  gofumpt:
-    extra-rules: true
-
-  govet:
-    enable-all: true
-
-  nakedret:
-    max-func-lines: 10
-
-  nestif:
-    min-complexity: 5
-
-  revive:
+    - whitespace
+  settings:
+    cyclop:
+      max-complexity: 15
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocognit:
+      min-complexity: 20
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gosec:
+      excludes:
+        - G104
+    govet:
+      enable-all: true
+    nakedret:
+      max-func-lines: 10
+    nestif:
+      min-complexity: 5
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: var-declaration
-      - name: var-naming
-
-  gosec:
-    excludes:
-      - G104  # errcheck がカバー
-
-  stylecheck:
-    checks:
-      - all
-
+      - linters:
+          - errcheck
+          - goconst
+          - gocritic
+          - gosec
+        path: _test\.go
+      - linters:
+          - cyclop
+          - gocognit
+        path: cmd/
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 50
   max-same-issues: 5
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - goconst
-        - gocritic
-        - errcheck
-        - gosec
-    - path: cmd/
-      linters:
-        - gocognit
-        - cyclop
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/docs/adr/003-golangci-lint-v2.md
+++ b/docs/adr/003-golangci-lint-v2.md
@@ -1,0 +1,40 @@
+# ADR-003: golangci-lint v2 への移行
+
+## ステータス
+承認
+
+## コンテキスト
+golangci-lint v1 系は v1.64.x をもって開発終了し、以降の Go バージョン対応・リンター更新は v2 系でのみ提供される。
+v2 は設定ファイル形式が非互換（`version: "2"` 必須、`linters-settings` → `linters.settings`、
+formatters の分離、`run.timeout` 廃止等）であり、CI 側も `golangci-lint-action@v6` は v2 バイナリに非対応のため
+action@v7 + バージョン明示が必要になる。
+
+2026-04 に v2 移行が着手されたが（別クローンでの手作業編集）、未完のまま放置されていた。
+手作業版には `linters-settings` トップレベル残存・`colored-line-number` 形式名・廃止済み `stylecheck` 設定という
+v2 非互換の誤りが含まれていた。
+
+## 決定
+- golangci-lint **v2.12.2** に更新し、設定は公式 `golangci-lint migrate` による機械変換を採用する
+- CI は `golangci/golangci-lint-action@v7` + `version: v2.12.2` の明示指定とする
+- 実効リンター集合は v1 時代と同等を維持する
+  - `typecheck` は v2 でリンターから除外（コンパイルエラーとして常時報告）
+  - `gosimple` / `stylecheck` は `staticcheck` に統合（`staticcheck.checks: all` で維持）
+  - `gofumpt` / `goimports` は `formatters` セクションに分離
+  - `errcheck` / `govet` / `ineffassign` / `unused` は v2 デフォルト有効のため enable 列挙から省略（設定は維持）
+
+## 選択肢
+| 選択肢 | 長所 | 短所 |
+|--------|------|------|
+| A: 公式 migrate で機械変換（採用） | 変換の正確性が保証される、v1 の実効挙動を維持 | v1 の暗黙デフォルト（exclusions presets）が明示化され設定が長くなる |
+| B: 手作業版（別クローンの編集）を採用 | 4月の作業を活用 | v2 非互換の誤りが3箇所あり、config verify を通らない |
+| C: v1.64.8 のまま維持 | 変更ゼロ | 開発終了系列のため新 Go バージョンで壊れる時限爆弾になる |
+
+## 検証
+- `golangci-lint config verify` パス
+- `golangci-lint run ./...` で 0 issues（v2.12.2）
+- `make check`（lint → test → build）パス
+
+## リスク
+- v2 の exclusions presets（`comments` / `common-false-positives` / `legacy` / `std-error-handling`）は
+  v1 の暗黙デフォルト除外を明示化したもの。将来 preset を外す場合は検出件数が増える
+- `run.timeout` は v2 でデフォルト無効。CI でハングした場合はジョブ側のタイムアウトで検出する

--- a/internal/reporter/github.go
+++ b/internal/reporter/github.go
@@ -80,7 +80,8 @@ func PostToGitHubPR(report *ImpactReport, owner, repo string, prNumber int, dryR
 }
 
 func findExistingComment(owner, repo string, prNumber int) (string, error) {
-	out, err := defaultRunner.Run("gh", "api",
+	out, err := defaultRunner.Run(
+		"gh", "api",
 		fmt.Sprintf("repos/%s/%s/issues/%d/comments", owner, repo, prNumber),
 		"--jq", fmt.Sprintf(`.[] | select(.body | contains(%q)) | .id`, commentMarker),
 	)
@@ -92,7 +93,8 @@ func findExistingComment(owner, repo string, prNumber int) (string, error) {
 }
 
 func createComment(owner, repo string, prNumber int, body string) error {
-	out, err := defaultRunner.Run("gh", "api",
+	out, err := defaultRunner.Run(
+		"gh", "api",
 		fmt.Sprintf("repos/%s/%s/issues/%d/comments", owner, repo, prNumber),
 		"-f", fmt.Sprintf("body=%s", body),
 	)
@@ -104,7 +106,8 @@ func createComment(owner, repo string, prNumber int, body string) error {
 }
 
 func updateComment(owner, repo, commentID, body string) error {
-	out, err := defaultRunner.Run("gh", "api",
+	out, err := defaultRunner.Run(
+		"gh", "api",
 		fmt.Sprintf("repos/%s/%s/issues/comments/%s", owner, repo, commentID),
 		"-X", "PATCH",
 		"-f", fmt.Sprintf("body=%s", body),


### PR DESCRIPTION
## 概要
golangci-lint を開発終了した v1 系（v1.64.8）から **v2.12.2** へ移行する（ADR-003）。
2026-04 に別クローンで着手され放置されていた移行作業の決着。

## 変更内容
- `.golangci.yml`: 公式 `golangci-lint migrate` による v2 形式への機械変換
  - 実効リンター集合は維持（`typecheck` は v2 で常時報告化、`gosimple`/`stylecheck` は `staticcheck` に統合、`gofumpt`/`goimports` は formatters に分離）
- `.github/workflows/ci.yml`: `golangci-lint-action@v6` → `v7`、`version: v1.64.8` → `v2.12.2`
- `docs/adr/003-golangci-lint-v2.md`: lint 設定変更の ADR（リポルール準拠）
- `internal/reporter/github.go`: v2.12.2 同梱の新 gofumpt による整形差分

## 検証
- [x] `golangci-lint config verify` パス
- [x] `golangci-lint run ./...` → 0 issues（v2.12.2）
- [x] `make check`（lint → test → build）全パス
- [x] `actionlint` OK